### PR TITLE
Add link to online executable version of example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ func main() {
 }
 ```
 
+Executable example: https://codeeval.dev/gist/ec81d16977f29daeb6c619ae8b61475d
+
 ## Supported Formats
 
 - [x] yesterday


### PR DESCRIPTION
I've made the example into an executable version to allow people to easily try out the library.

The code is stored as a gist (https://gist.github.com/kjk/ec81d16977f29daeb6c619ae8b61475d) and is made executable by https://codeeval.dev/ (an enhanced Go playground that I've made).

Hope this is useful.